### PR TITLE
Bump CASE validation to CASE 1.1.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     # Checkout the repository for processing
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Test the output files to confirm they're both conformant to the CASE Ontology
     - name: CASE Validation

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,7 +21,7 @@ jobs:
 
     # Test the output files to confirm they're both conformant to the CASE Ontology
     - name: CASE Validation
-      uses: kchason/case-validation-action@v2.3
+      uses: kchason/case-validation-action@v2.5
       with:
         case-path: ./json/
-        case-version: "case-1.0.0"
+        case-version: "case-1.1.0"


### PR DESCRIPTION
If I recall correctly, this will still fail CI due to needing other code updates. But, merging this will introduce the [IRI typo-checker](https://github.com/casework/CASE-Utilities-Python/issues/40) to CI.