### PR TITLE
Bump checkout to v3

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     # Checkout the repository for processing
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Test the output files to confirm they're both conformant to the CASE Ontology
     - name: CASE Validation


### PR DESCRIPTION
References:
* https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/